### PR TITLE
Add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Instructions for Codex Agents
+
+## Formatting and Linting
+- Always run `cargo fmt --all` to format Rust code before committing.
+- Optionally, run `cargo clippy` to check for lints, but it is not required for PRs.
+
+## Tests
+- Run `cargo test` to ensure that unit and integration tests pass.
+- If tests fail due to missing dependencies or environment limitations, note it in the PR.
+
+## Running Rustlings
+- Use `cargo run -- -V` to verify the Rustlings version.
+- You can also run exercises or check them with `cargo run -- run <exercise>` or `cargo run -- check-all`.
+


### PR DESCRIPTION
## Summary
- add instructions for Codex agents in AGENTS.md

## Testing
- `cargo run -- -V`
- `cargo test -- --nocapture` *(fails: Broken pipe)*

------
https://chatgpt.com/codex/tasks/task_e_6840cfa665dc832a85785a21521b822f